### PR TITLE
Fix permissions in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
 FROM ruby:latest
 
-USER root
-
-RUN mkdir src
-WORKDIR src
+RUN mkdir /src && \
+    mkdir /src/log /src/tmp && \
+    touch /src/log/production.log
+WORKDIR /src
 COPY . .
 
 RUN bundle install
-RUN mkdir -p log
-RUN touch log/production.log
-RUN chmod 664 log/production.log
 RUN RAILS_ENV=production rake assets:precompile
 
+RUN chmod -R g+rw /src/log /src/tmp
+
+USER 1001
 EXPOSE 8080
 CMD bundle exec unicorn -p 8080 -c ./config/unicorn.rb


### PR DESCRIPTION
The OpenShift builder runs with a more privileged security policy with user root:root, but when the pod is deployed it runs with a more restricted security policy. The user your deployment runs in will not be the same user the build runs in, so any files copied in the build step will not necessarily have the correct permissions for the deployment user.

So best practices with Dockerfiles for OpenShift:
 - Specify a new user in the Dockerfile, e.g. `USER 1001`. By default this will have group 0 (root).
 - Files that you copy before specifying the user will be owned by root:root with permissions 0644 so this new user will not be able to write to the files.
 - To ensure the user can write to any files it needs to we should make the files group writeable, e.g. `chmod -R g+rw <dir>`